### PR TITLE
Add wildcard to AWS partition in ARN validation

### DIFF
--- a/templates/nomad_custom_data.sh.tpl
+++ b/templates/nomad_custom_data.sh.tpl
@@ -201,7 +201,7 @@ function retrieve_license_from_awssm {
     if [[ -z "$SECRET_ARN" ]]; then
         log "ERROR" "Secret ARN cannot be empty. Exiting."
         exit_script 4
-    elif [[ "$SECRET_ARN" == arn:aws:secretsmanager:* ]]; then
+    elif [[ "$SECRET_ARN" == arn:aws*:secretsmanager:* ]]; then
         log "INFO" "Retrieving value of secret '$SECRET_ARN' from AWS Secrets Manager."
         NOMAD_LICENSE=$(aws secretsmanager get-secret-value --region $SECRET_REGION --secret-id $SECRET_ARN --query SecretString --output text)
         echo "$NOMAD_LICENSE" >$NOMAD_LICENSE_PATH
@@ -221,7 +221,7 @@ function retrieve_certs_from_awssm {
     if [[ -z "$SECRET_ARN" ]]; then
         log "ERROR" "Secret ARN cannot be empty. Exiting."
         exit_script 5
-    elif [[ "$SECRET_ARN" == arn:aws:secretsmanager:* ]]; then
+    elif [[ "$SECRET_ARN" == arn:aws*:secretsmanager:* ]]; then
         log "INFO" "Retrieving value of secret '$SECRET_ARN' from AWS Secrets Manager."
         CERT_DATA=$(aws secretsmanager get-secret-value --region $SECRET_REGION --secret-id $SECRET_ARN --query SecretString --output text)
         echo "$CERT_DATA" | base64 -d >$DESTINATION_PATH
@@ -238,7 +238,7 @@ function retrieve_gossip_encryption_key_from_awssm {
     if [[ -z "$SECRET_ARN" ]]; then
         log "ERROR" "Secret ARN cannot be empty. Exiting."
         exit_script 5
-    elif [[ "$SECRET_ARN" == arn:aws:secretsmanager:* ]]; then
+    elif [[ "$SECRET_ARN" == arn:aws*:secretsmanager:* ]]; then
         log "INFO" "Retrieving value of secret '$SECRET_ARN' from AWS Secrets Manager."
         GOSSIP_ENCRYPTION_KEY=$(aws secretsmanager get-secret-value --region $SECRET_REGION --secret-id $SECRET_ARN --query SecretString --output text)
     else


### PR DESCRIPTION
This PR updates ARN validation patterns to use wildcards for AWS partitions, allowing the module to work across different AWS partitions (aws, aws-us-gov, aws-cn, etc.).