### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+## v0.3.0
+
+## What's Changed
+* Fix prepare disk by @jeffmccollum in https://github.com/hashicorp/terraform-aws-nomad-enterprise-hvd/pull/7
+* Abc hdm 151 updates by @abuxton in https://github.com/hashicorp/terraform-aws-nomad-enterprise-hvd/pull/8
+* upstream merge template repository by @github-actions[bot] in https://github.com/hashicorp/terraform-aws-nomad-enterprise-hvd/pull/9
+* upstream merge template repository by @github-actions[bot] in https://github.com/hashicorp/terraform-aws-nomad-enterprise-hvd/pull/10
+* Chore/abc-add-workflow-permissions by @abuxton in https://github.com/hashicorp/terraform-aws-nomad-enterprise-hvd/pull/11
+* [IND-4227] [COMPLIANCE] Update Copyright Headers (Batch 1 of 1) by @oss-core-libraries-dashboard[bot] in https://github.com/hashicorp/terraform-aws-nomad-enterprise-hvd/pull/12
+* upstream merge template repository by @github-actions[bot] in https://github.com/hashicorp/terraform-aws-nomad-enterprise-hvd/pull/13
+* Add wildcard to AWS partition in ARN validation by @abuxton in https://github.com/hashicorp/terraform-aws-nomad-enterprise-hvd/pull/14
+* [COMPLIANCE] Add/Update Copyright Headers by @hashicorp-copywrite[bot] in https://github.com/hashicorp/terraform-aws-nomad-enterprise-hvd/pull/16
+* manual sync by @abuxton in https://github.com/hashicorp/terraform-aws-nomad-enterprise-hvd/pull/15
+* [COMPLIANCE] Add/Update Copyright Headers by @hashicorp-copywrite[bot] in https://github.com/hashicorp/terraform-aws-nomad-enterprise-hvd/pull/17
+* upstream merge template repository by @github-actions[bot] in https://github.com/hashicorp/terraform-aws-nomad-enterprise-hvd/pull/19
+* upstream merge template repository by @github-actions[bot] in https://github.com/hashicorp/terraform-aws-nomad-enterprise-hvd/pull/18
+* [COMPLIANCE] Add/Update Copyright Headers by @hashicorp-copywrite[bot] in https://github.com/hashicorp/terraform-aws-nomad-enterprise-hvd/pull/21
+
+## New Contributors
+* @abuxton made their first contribution in https://github.com/hashicorp/terraform-aws-nomad-enterprise-hvd/pull/8
+* @oss-core-libraries-dashboard[bot] made their first contribution in https://github.com/hashicorp/terraform-aws-nomad-enterprise-hvd/pull/12
+* @hashicorp-copywrite[bot] made their first contribution in https://github.com/hashicorp/terraform-aws-nomad-enterprise-hvd/pull/16
+
+**Full Changelog**: https://github.com/hashicorp/terraform-aws-nomad-enterprise-hvd/compare/0.2.0...0.3.0
+


### PR DESCRIPTION
This PR proposes cutting **0.3.0**. It adds `CHANGELOG.md` for this release. The full change list is in that file; the proposed 0.3.0 release notes are reproduced below for review. Once this is approved, I'll cut the 0.3.0 tag and publish the release. Please
flag any corrections to the notes.

## Overview

37 commits since `0.2.0`. Adds a customizable install-template option, reworks Nomad binary installation with signature/checksum verification, caps the AWS provider at the 5.x series, and adds wildcard AWS-partition support in ARN
validation, alongside compliance and template-sync maintenance.

## Breaking changes

- The reworked install template changes the launch template / user_data, so applying this version may trigger an Auto Scaling Group instance refresh, replacing existing Nomad nodes during rollout. (`5d56ddd`)
- Installation now requires outbound access to `releases.hashicorp.com` and the HashiCorp PGP key endpoint; air-gapped or restricted-network deployments must account for this. (`5d56ddd`)

## New features

- Added `custom_install_template` input, allowing a user-supplied install script template (placed under `./templates`) to replace the built-in user_data script. Defaults to `null`, so existing deployments are unaffected. (`5d56ddd`)
- Added wildcard AWS-partition support in ARN validation (e.g. GovCloud, China). (`64fd2f7`)

## Improvements

- Reworked Nomad binary installation to download from releases.hashicorp.com with GPG signature and SHA256 checksum verification. (`5d56ddd`)
- Added automatic OS architecture detection (`dpkg --print-architecture`) and improved package handling (e.g. gnupg2 on AL2023). (`784cffc`, `f30a8d8`)
- Updated default example configuration for the new install options. (`6962b03`)

## Bug fixes

- Install script syntax and reliability fixes surfaced during review. (`61c52d9`)

## Compliance and infrastructure

- Updated copyright and license headers. (`8882810`, `77dba33`, `482a819`, `cd573b1`)
- Template-sync and workflow-permission maintenance from the module template.

## Documentation

- Updated README provider/requirement tables to reflect the AWS constraint change. (`5d56ddd`)

## Dependencies

| Dependency | Status | Notes |
|------------|--------|-------|
| hashicorp/aws | constraint changed | `>= 5.51.0` → `~> 5.0`. Now pinned within the 5.x major series (6.x no longer permitted), while lowering the minor floor below 5.51. Review against your environment. |

## Upgrade Guide

### From 0.2.0 to 0.3.0

1. The reworked install template may trigger an ASG instance refresh. Plan a controlled rollout, as existing Nomad nodes may be replaced during convergence.
2. Ensure target environments can reach `releases.hashicorp.com` and the HashiCorp PGP key endpoint, as installation now verifies signatures and checksums.
3. Review the AWS provider constraint change (`>= 5.51.0` → `~> 5.0`); aws provider 6.x is no longer permitted by this module.
4. If adopting `custom_install_template`, place your template file under a `./templates` directory relative to your working directory.
5. Run `terraform plan` and validate in a non-production environment before rollout.

## Contributors

- Adam Buxton
- Jeff McCollum
- Mark Lewis
- Mekki MacAulay
- Tolu Williams
- Tristan Morgan
- pjohnson24

### Automated contributors

- github-actions[bot]
- hashicorp-copywrite[bot]